### PR TITLE
Close #61 - debugged datatype3 field and added draft cheatSheet node

### DIFF
--- a/public/cheatSheets/db_javascript_node_psql_bookshelf_knex_cheatsheet.md
+++ b/public/cheatSheets/db_javascript_node_psql_bookshelf_knex_cheatsheet.md
@@ -1,0 +1,32 @@
+# DataBoss Command Cheat Sheet
+
+Language: JavaScript
+Framework: Node.js
+ORM: Bookshelf.js built on the Knex SQL query builder
+DB: PostgreSQL
+
+## Commands:
+
+### Install Knex and Bookshelf
+
+`$ npm install knex --save`
+`$ npm install bookshelf --save`
+
+# Then add PostgreSQL database:
+`$ npm install pg`
+
+
+### Setup a database schema with help from Knex to generate migrations
+
+`$ knex init`  
+
+This generates a basic configuration file, 'knexfile.js':  
+
+`module.exports = {
+  development: {
+    client: 'pg',
+    connection: {
+      filename: './dev.movies'
+    }
+  }
+};`

--- a/views/partials/table2.ejs
+++ b/views/partials/table2.ejs
@@ -17,7 +17,7 @@
 <div class="col s4">
 </div>
 <div class="input-field col s8" id="input-box">
-  <select id="dataType3" name="dataType"></select>
+  <select id="dataType3" name="dataType3"></select>
 </div>
 
 <div class="col s4">


### PR DESCRIPTION
#61

CheatSheet for node.js  and bookshelf.js not to be used for demo. Not straightforward. Many version errors for setting up when tested on a dummy project repo.
